### PR TITLE
[Feat] - Enum 생성 및 적용

### DIFF
--- a/src/main/java/backend/spring/entity/Movie.java
+++ b/src/main/java/backend/spring/entity/Movie.java
@@ -1,7 +1,13 @@
 package backend.spring.entity;
 
+import backend.spring.entity.type.Emotion;
+import backend.spring.entity.type.Genre;
+import backend.spring.entity.type.Origin;
+import backend.spring.entity.type.Style;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -48,15 +54,19 @@ public class Movie {
 	@Column(nullable = false)
 	private String actor2;
 
+	@Enumerated(EnumType.STRING)
 	@Column(nullable = false)
-	private String genre;
+	private Genre genre;
 
+	@Enumerated(EnumType.STRING)
 	@Column(nullable = false)
-	private String origin;
+	private Origin origin;
 
+	@Enumerated(EnumType.STRING)
 	@Column(nullable = false)
-	private String emotion;
+	private Emotion emotion;
 
+	@Enumerated(EnumType.STRING)
 	@Column(nullable = false)
-	private String style;
+	private Style style;
 }

--- a/src/main/java/backend/spring/entity/TodayWord.java
+++ b/src/main/java/backend/spring/entity/TodayWord.java
@@ -1,7 +1,12 @@
 package backend.spring.entity;
 
+import backend.spring.entity.type.Emotion;
+import backend.spring.entity.type.Style;
+import backend.spring.entity.type.Tone;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -21,22 +26,34 @@ public class TodayWord {
 	@Column(name = "word_id", nullable = false)
 	private Long id;
 
+	@Enumerated(EnumType.STRING)
 	@Column(nullable = false)
-	private String emotion;
+	private Emotion emotion;
 
+	@Enumerated(EnumType.STRING)
 	@Column(nullable = false)
-	private String style;
+	private Style style;
 
+	@Enumerated(EnumType.STRING)
 	@Column(nullable = false)
-	private String tone;
+	private Tone tone;
 
 	@Column(columnDefinition = "TEXT", nullable = false)
 	private String word;
 
-	public TodayWord(String emotion, String style, String tone, String word) {
+	public TodayWord(Emotion emotion, Style style, Tone tone, String word) {
 		this.emotion = emotion;
 		this.style = style;
 		this.tone = tone;
 		this.word = word;
+	}
+	
+	public static TodayWord of(String emotion, String style, String tone, String word) {
+		return new TodayWord(
+			Emotion.from(emotion),
+			Style.from(style),
+			Tone.from(tone),
+			word
+		);
 	}
 }

--- a/src/main/java/backend/spring/entity/VisitorTag.java
+++ b/src/main/java/backend/spring/entity/VisitorTag.java
@@ -61,4 +61,16 @@ public class VisitorTag {
 		this.origin = origin;
 		this.hate = hate;
 	}
+
+	public static VisitorTag of(Visitor visitor, String emotion, String style, String genre, String origin,
+		String hate) {
+		return new VisitorTag(
+			visitor,
+			Emotion.from(emotion),
+			Style.from(style),
+			Genre.from(genre),
+			Origin.from(origin),
+			Genre.from(genre)
+		);
+	}
 }

--- a/src/main/java/backend/spring/entity/VisitorTag.java
+++ b/src/main/java/backend/spring/entity/VisitorTag.java
@@ -1,7 +1,13 @@
 package backend.spring.entity;
 
+import backend.spring.entity.type.Emotion;
+import backend.spring.entity.type.Genre;
+import backend.spring.entity.type.Origin;
+import backend.spring.entity.type.Style;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -27,22 +33,27 @@ public class VisitorTag {
 	@JoinColumn(name = "visitor_id", nullable = false)
 	private Visitor visitor;
 
+	@Enumerated(EnumType.STRING)
 	@Column(nullable = false)
-	private String emotion;
+	private Emotion emotion;
 
+	@Enumerated(EnumType.STRING)
 	@Column(nullable = false)
-	private String style;
+	private Style style;
 
+	@Enumerated(EnumType.STRING)
 	@Column(nullable = false)
-	private String genre;
+	private Genre genre;
 
+	@Enumerated(EnumType.STRING)
 	@Column(nullable = false)
-	private String origin;
+	private Origin origin;
 
+	@Enumerated(EnumType.STRING)
 	@Column(nullable = false)
-	private String hate;
+	private Genre hate;
 
-	public VisitorTag(Visitor visitor, String emotion, String style, String genre, String origin, String hate) {
+	public VisitorTag(Visitor visitor, Emotion emotion, Style style, Genre genre, Origin origin, Genre hate) {
 		this.visitor = visitor;
 		this.emotion = emotion;
 		this.style = style;

--- a/src/main/java/backend/spring/entity/type/Emotion.java
+++ b/src/main/java/backend/spring/entity/type/Emotion.java
@@ -1,0 +1,27 @@
+package backend.spring.entity.type;
+
+import static backend.spring.exception.ResponseCode.*;
+
+import java.util.Arrays;
+
+import backend.spring.exception.CustomException;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Emotion {
+	SAD("슬픔"),
+	HAPPY("행복"),
+	BORED("지루함"),
+	STRESSED("스트레스");
+
+	private final String name;
+
+	public static Emotion from(String name) {
+		return Arrays.stream(values())
+			.filter(e -> e.name.equals(name))
+			.findFirst()
+			.orElseThrow(() -> new CustomException(INVALID_ENUM_FORMAT));
+	}
+}

--- a/src/main/java/backend/spring/entity/type/Genre.java
+++ b/src/main/java/backend/spring/entity/type/Genre.java
@@ -1,0 +1,29 @@
+package backend.spring.entity.type;
+
+import static backend.spring.exception.ResponseCode.*;
+
+import java.util.Arrays;
+
+import backend.spring.exception.CustomException;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Genre {
+	ROMANCE("로맨스"),
+	COMEDY("코미디"),
+	ANIMATION("애니메이션"),
+	DRAMA("드라마"),
+	ACTION("액션"),
+	THRILLER("스릴러");
+
+	private final String name;
+
+	public static Genre from(String name) {
+		return Arrays.stream(values())
+			.filter(e -> e.name.equals(name))
+			.findFirst()
+			.orElseThrow(() -> new CustomException(INVALID_ENUM_FORMAT));
+	}
+}

--- a/src/main/java/backend/spring/entity/type/Origin.java
+++ b/src/main/java/backend/spring/entity/type/Origin.java
@@ -1,0 +1,27 @@
+package backend.spring.entity.type;
+
+import static backend.spring.exception.ResponseCode.*;
+
+import java.util.Arrays;
+
+import backend.spring.exception.CustomException;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Origin {
+	KOREA("한국"),
+	EAST_ASIA("동아시아"),
+	WEST("서구"),
+	OTHER("기타");
+
+	private final String name;
+
+	public static Origin from(String name) {
+		return Arrays.stream(values())
+			.filter(e -> e.name.equals(name))
+			.findFirst()
+			.orElseThrow(() -> new CustomException(INVALID_ENUM_FORMAT));
+	}
+}

--- a/src/main/java/backend/spring/entity/type/Style.java
+++ b/src/main/java/backend/spring/entity/type/Style.java
@@ -1,0 +1,28 @@
+package backend.spring.entity.type;
+
+import static backend.spring.exception.ResponseCode.*;
+
+import java.util.Arrays;
+
+import backend.spring.exception.CustomException;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Style {
+	REFRESHING("기분전환"),
+	COMFORTING("위로"),
+	IMMERSIVE("몰입감"),
+	FUNNY("웃긴");
+
+	private final String name;
+
+	public static Style from(String name) {
+		return Arrays.stream(values())
+			.filter(e -> e.name.equals(name))
+			.findFirst()
+			.orElseThrow(() -> new CustomException(INVALID_ENUM_FORMAT));
+	}
+}
+

--- a/src/main/java/backend/spring/entity/type/Tone.java
+++ b/src/main/java/backend/spring/entity/type/Tone.java
@@ -1,0 +1,27 @@
+package backend.spring.entity.type;
+
+import static backend.spring.exception.ResponseCode.*;
+
+import java.util.Arrays;
+
+import backend.spring.exception.CustomException;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Tone {
+	COMFORT("위로"),
+	ADVICE("조언"),
+	MOTIVATION("동기부여"),
+	CHEER("응원");
+
+	private final String name;
+
+	public static Tone from(String name) {
+		return Arrays.stream(values())
+			.filter(e -> e.name.equals(name))
+			.findFirst()
+			.orElseThrow(() -> new CustomException(INVALID_ENUM_FORMAT));
+	}
+}

--- a/src/main/java/backend/spring/exception/ResponseCode.java
+++ b/src/main/java/backend/spring/exception/ResponseCode.java
@@ -8,7 +8,8 @@ public enum ResponseCode {
 	MOVIE_NOT_FOUND(404, "영화를 찾을 수 없습니다."),
 	NO_RECOMMENDATION_FOUND(404, "조건에 맞는 영화가 없습니다."),
 	INVALID_FORMAT(400, "잘못된 입력 형식 입니다."),
-	OPENAI_LIMIT(400, "gpt api의 사용량을 초과했습니다.");
+	OPENAI_LIMIT(400, "gpt api의 사용량을 초과했습니다."),
+	INVALID_ENUM_FORMAT(400, "잘못된 입력 형식입니다.");
 
 	private final int status;
 	private final String message;

--- a/src/main/java/backend/spring/service/MovieInfoService.java
+++ b/src/main/java/backend/spring/service/MovieInfoService.java
@@ -28,13 +28,13 @@ public class MovieInfoService {
 			movie.getHour(),
 			movie.getYear(),
 			fullImageUrl,
-			movie.getGenre(),
+			movie.getGenre().getName(),
 			movie.getSummary(),
 			movie.getScore(),
 			movie.getDirector(),
 			movie.getActor1(),
 			movie.getActor2(),
-			movie.getOrigin()
+			movie.getOrigin().getName()
 		);
 	}
 }

--- a/src/main/java/backend/spring/service/OpenAiService.java
+++ b/src/main/java/backend/spring/service/OpenAiService.java
@@ -90,7 +90,7 @@ public class OpenAiService {
 				Map message = (Map)choice.get("message");
 				String content = (String)message.get("content");
 
-				todayWordRepository.save(new TodayWord(emotion, style, tone, content));
+				todayWordRepository.save(TodayWord.of(emotion, style, tone, content));
 				return Mono.just(new ChatResponseDto(content));
 			})
 			.onErrorResume(WebClientResponseException.TooManyRequests.class, e -> {

--- a/src/main/java/backend/spring/service/RecommendService.java
+++ b/src/main/java/backend/spring/service/RecommendService.java
@@ -73,16 +73,15 @@ public class RecommendService {
 			.limit(3)
 			.toList();
 
-		VisitorTag tag = new VisitorTag(
-			visitor,
-			Emotion.from(request.emotion()),
-			Style.from(request.style()),
-			Genre.from(request.genre()),
-			Origin.from(request.origin()),
-			Genre.from(request.hate())
-		);
-		visitorTagRepository.save(tag);
 
+		visitorTagRepository.save(VisitorTag.of(
+			visitor,
+			request.emotion(),
+			request.style(),
+			request.genre(),
+			request.origin(),
+			request.hate()
+		));
 
 		return recommended.stream()
 			.map(movie -> new RecommendMovieResponseDto(

--- a/src/main/java/backend/spring/service/RecommendService.java
+++ b/src/main/java/backend/spring/service/RecommendService.java
@@ -13,6 +13,10 @@ import backend.spring.dto.response.RecommendMovieResponseDto;
 import backend.spring.entity.Movie;
 import backend.spring.entity.Visitor;
 import backend.spring.entity.VisitorTag;
+import backend.spring.entity.type.Emotion;
+import backend.spring.entity.type.Genre;
+import backend.spring.entity.type.Origin;
+import backend.spring.entity.type.Style;
 import backend.spring.exception.CustomException;
 import backend.spring.exception.ResponseCode;
 import backend.spring.repository.MovieRepository;
@@ -71,11 +75,11 @@ public class RecommendService {
 
 		VisitorTag tag = new VisitorTag(
 			visitor,
-			request.emotion(),
-			request.style(),
-			request.genre(),
-			request.origin(),
-			request.hate()
+			Emotion.from(request.emotion()),
+			Style.from(request.style()),
+			Genre.from(request.genre()),
+			Origin.from(request.origin()),
+			Genre.from(request.hate())
 		);
 		visitorTagRepository.save(tag);
 


### PR DESCRIPTION
## 📝 요약(Summary)

### ➡️ Enum 도입
- 값이 고정된 `Emotion`, `Genre`, `Origin`, `Style`, `Tone`을 **Enum으로 리팩토링**하여 타입 안정성을 높이고 코드 가독성을 개선했습니다. 
- 기존 `MovieInfoResponseDto`에서 `Genre`, `Origin`은 API 응답 시 Enum의 name을 String으로 반환해야 했기에, **Enum 클래스에 name 필드를 추가**했습니다.
    - **통일성과 가독성을 위해 다른 Enum 클래스들도 동일하게 name 필드를 추가**했습니다. 나중에 다른 곳에서도 Enum의 표시용 값을 사용할 때 일관성을 유지할 수 있습니다.
- 서비스 로직이나 Request에서 **String 값으로 넘어온 데이터를 Enum으로 변환**하기 위해 아래와 같이 각 Enum 클래스에 **`from()` 메서드를 추가**했습니다.
```java
public static Emotion from(String name) {
    return Arrays.stream(values())
	.filter(e -> e.name.equals(name))
	.findFirst()
	.orElseThrow(() -> new CustomException(INVALID_ENUM_FORMAT));
}
```

### ➡️ Enum 적용 (in Service, Entity)
- `TodayWord` 엔티티에서는 외부 서비스(OpenAiService)로부터 받은 **String 값을 Enum으로 안전하게 매핑**하여 저장하기 위해 **정적 팩토리 메서드 `of()`를 추가**했습니다.
```java
public static TodayWord of(String emotion, String style, String tone, String word) {
    return new TodayWord(
	Emotion.from(emotion),
	Style.from(style),
	Tone.from(tone),
	word
    );
}
```
- `OpenAiService`에서는 **`todayWordRepository.save(TodayWord.of(emotion, style, tone, content));`** 이렇게 위 정적 팩토리 메서드를 호출하여 TodayWord를 생성합니다.

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 공유사항 to 리뷰어
- Enum 도입으로 기존의 다른 클래스들이 변경되어었으니 꼼꼼히 확인 부탁드립니다.
- 현재 `OpenAiService`에서는 AI로부터 받은 String 값을 그대로 전달받아 `TodayWord.of()` 메서드에서 Enum으로 매핑하도록 처리했습니다.
    - 서비스 계층에서 String 대신 Enum으로 변환된 값을 넘겨주도록 한다면  of 메서드가 필요없어질 수 있습니다. 
    - 즉 서비스에서 Enum 변환을 담당하도록 리팩토링 하셔도 됩니다.
    - 추후 은서님이 선택하시면 될 거 같습니당  

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
