### PR TITLE
[Refactor] - 영화 추천 로직 개선

### DIFF
--- a/src/main/java/backend/spring/exception/GlobalExceptionHandler.java
+++ b/src/main/java/backend/spring/exception/GlobalExceptionHandler.java
@@ -2,9 +2,9 @@ package backend.spring.exception;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
 
-@RestController
+@RestControllerAdvice
 public class GlobalExceptionHandler {
 
 	@ExceptionHandler(CustomException.class)

--- a/src/main/java/backend/spring/repository/MovieRepository.java
+++ b/src/main/java/backend/spring/repository/MovieRepository.java
@@ -1,12 +1,28 @@
 package backend.spring.repository;
 
 import java.util.List;
+import java.util.Set;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import backend.spring.entity.Movie;
 
 public interface MovieRepository extends JpaRepository<Movie, Long> {
 
-	List<Movie> findAllByGenreNot(String genre);
+	@Query(value = "SELECT * FROM (" +
+		"SELECT *, " +
+		"( (CASE WHEN emotion IN :tags THEN 1 ELSE 0 END) + " +
+		"  (CASE WHEN style IN :tags THEN 1 ELSE 0 END) + " +
+		"  (CASE WHEN genre IN :tags THEN 1 ELSE 0 END) + " +
+		"  (CASE WHEN origin IN :tags THEN 1 ELSE 0 END) " +
+		") AS match_count " +
+		"FROM movies " +
+		"WHERE genre <> :hate " +
+		"AND (emotion IN :tags OR style IN :tags OR genre IN :tags OR origin IN :tags) " +
+		") AS temp " +
+		"ORDER BY match_count DESC, RAND() " +
+		"LIMIT 3", nativeQuery = true)
+	List<Movie> findRecommendedMovies(@Param("tags") Set<String> tags, @Param("hate") String hate);
 }

--- a/src/main/java/backend/spring/service/RecommendService.java
+++ b/src/main/java/backend/spring/service/RecommendService.java
@@ -1,10 +1,7 @@
 package backend.spring.service;
 
-import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 
@@ -13,10 +10,6 @@ import backend.spring.dto.response.RecommendMovieResponseDto;
 import backend.spring.entity.Movie;
 import backend.spring.entity.Visitor;
 import backend.spring.entity.VisitorTag;
-import backend.spring.entity.type.Emotion;
-import backend.spring.entity.type.Genre;
-import backend.spring.entity.type.Origin;
-import backend.spring.entity.type.Style;
 import backend.spring.exception.CustomException;
 import backend.spring.exception.ResponseCode;
 import backend.spring.repository.MovieRepository;
@@ -38,8 +31,6 @@ public class RecommendService {
 		Visitor visitor = visitorRepository.findById(visitorId)
 			.orElseThrow(() -> new CustomException(ResponseCode.USER_NOT_FOUND));
 
-		List<Movie> allMovies = movieRepository.findAllByGenreNot(request.hate());
-
 		Set<String> tags = Set.of(
 			request.emotion(),
 			request.style(),
@@ -47,32 +38,10 @@ public class RecommendService {
 			request.origin()
 		);
 
-		Map<Movie, Long> matchCountMap = allMovies.stream()
-			.collect(Collectors.toMap(
-				movie -> movie,
-				movie -> tags.stream()
-					.filter(tag -> tag.equals(movie.getEmotion())
-						|| tag.equals(movie.getStyle())
-						|| tag.equals(movie.getGenre())
-						|| tag.equals(movie.getOrigin()))
-					.count()
-			));
-
-		List<Movie> matchMovies = matchCountMap.entrySet().stream()
-			.filter(entry -> entry.getValue() > 0)
-			.sorted((a, b) -> Long.compare(b.getValue(), a.getValue()))
-			.map(Map.Entry::getKey)
-			.collect(Collectors.toList());
-
-		if (matchMovies.isEmpty()) {
+		List<Movie> recommended = movieRepository.findRecommendedMovies(tags, request.hate());
+		if (recommended.isEmpty()) {
 			throw new CustomException(ResponseCode.NO_RECOMMENDATION_FOUND);
 		}
-
-		Collections.shuffle(matchMovies);
-		List<Movie> recommended = matchMovies.stream()
-			.limit(3)
-			.toList();
-
 
 		visitorTagRepository.save(VisitorTag.of(
 			visitor,


### PR DESCRIPTION
## #️⃣ Issue Number
#31 
<!--- ex) #이슈번호, #이슈번호 -->

## 📝 요약(Summary)
### 👉 기존 코드의 문제점
- 전체 영화를 조회하고 서비스 내에서 태그 매칭 및 정렬 처리 → 데이터 양이 많을수록 성능 저하
- 추천 로직이 서비스에 집중되어 레포지토리 역할 분리가 미흡
- 태그 매칭을 스트림 필터로 처리해 비효율적
- `Collections.shuffle`과 `Stream limit`으로 비효율적인 랜덤 처리

### 👉 개선 
- 요청 태그를 **Enum 변환 후 DB `Enum.name()`과 매칭 처리**
- 레포지토리에서 **Native Query**로 match_count 계산 및 랜덤 추천 처리
- 추천 결과 없을 시 `CustomException` 처리 및 전역 예외 처리 적용

### 👉 Native Query 도입
- **JPQL ?**
      - JPQL은 match_count 계산, LIMIT 처리 불가
      - 복잡한 조건일수록 문자열 쿼리 관리 어려움
- **QueryDSL ?**
      - QueryDSL은 match_count 계산과 랜덤 정렬을 코드로 작성하면 복잡
      - MySQL 전용 RAND()와 LIMIT 지원이 불편하고 코드량 증가
```java
SELECT * FROM (
    SELECT *, 
    ( (CASE WHEN emotion IN :tags THEN 1 ELSE 0 END) +
      (CASE WHEN style IN :tags THEN 1 ELSE 0 END) +
      (CASE WHEN genre IN :tags THEN 1 ELSE 0 END) +
      (CASE WHEN origin IN :tags THEN 1 ELSE 0 END)
    ) AS match_count
    FROM movies
    WHERE genre <> :hate
    AND (emotion IN :tags OR style IN :tags OR genre IN :tags OR origin IN :tags)
) AS temp
ORDER BY match_count DESC, RAND()
LIMIT 3
```
1.  movies 테이블에서 요청 태그(`Emotion`, `Style`, `Genre`, `Origin`) 중 일치하는 컬럼마다 match_count 계산
2. `genre <> :hate` 조건으로 제외할 장르 필터링
3. **서브쿼리(`AS temp`)** 로 match_count 계산된 결과를 임시 테이블로 생성
4. 임시 테이블에서 **`match_count DESC` (많은 태그 일치 우선), `RAND()` (랜덤 정렬)** 으로 추천 영화 정렬
5. `LIMIT` 3으로 추천 영화 3개만 추출

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 공유사항 to 리뷰어
- 예외처리는 테스트 했으나, 현재 영화 데이터를 모두 지웠기 때문에 데이터를 넣고난 후 테스트가 필요합니다.

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
