### PR TITLE
[Feat] - HTML 결과 저장 및 공유 링크 생성 기능 추가

### DIFF
--- a/src/main/java/backend/spring/controller/HtmlShareController.java
+++ b/src/main/java/backend/spring/controller/HtmlShareController.java
@@ -1,0 +1,26 @@
+package backend.spring.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import backend.spring.dto.request.HtmlSaveRequest;
+import backend.spring.dto.response.HtmlSaveResponse;
+import backend.spring.service.HtmlShareService;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("api/html")
+@RequiredArgsConstructor
+public class HtmlShareController {
+
+	private final HtmlShareService htmlShareService;
+
+	@PostMapping("/save")
+	public ResponseEntity<HtmlSaveResponse> saveHtml(@RequestBody HtmlSaveRequest request) {
+		HtmlSaveResponse response = htmlShareService.saveHtml(request.html());
+		return ResponseEntity.ok(response);
+	}
+}

--- a/src/main/java/backend/spring/dto/request/HtmlSaveRequest.java
+++ b/src/main/java/backend/spring/dto/request/HtmlSaveRequest.java
@@ -1,0 +1,4 @@
+package backend.spring.dto.request;
+
+public record HtmlSaveRequest(String html) {
+}

--- a/src/main/java/backend/spring/dto/response/HtmlSaveResponse.java
+++ b/src/main/java/backend/spring/dto/response/HtmlSaveResponse.java
@@ -1,0 +1,4 @@
+package backend.spring.dto.response;
+
+public record HtmlSaveResponse(String url) {
+}

--- a/src/main/java/backend/spring/exception/ResponseCode.java
+++ b/src/main/java/backend/spring/exception/ResponseCode.java
@@ -9,7 +9,9 @@ public enum ResponseCode {
 	NO_RECOMMENDATION_FOUND(404, "조건에 맞는 영화가 없습니다."),
 	INVALID_FORMAT(400, "잘못된 입력 형식 입니다."),
 	OPENAI_LIMIT(400, "gpt api의 사용량을 초과했습니다."),
-	INVALID_ENUM_FORMAT(400, "잘못된 입력 형식입니다.");
+	INVALID_ENUM_FORMAT(400, "잘못된 입력 형식입니다."),
+	INVALID_HTML_FORMAT(400, "HTML 내용이 비어 있습니다."),
+	FILE_SAVE_ERROR(500, "HTML 파일 저장 중 오류가 발생했습니다.");
 
 	private final int status;
 	private final String message;

--- a/src/main/java/backend/spring/service/HtmlShareService.java
+++ b/src/main/java/backend/spring/service/HtmlShareService.java
@@ -1,0 +1,44 @@
+package backend.spring.service;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import backend.spring.dto.response.HtmlSaveResponse;
+import backend.spring.exception.CustomException;
+import backend.spring.exception.ResponseCode;
+
+@Service
+public class HtmlShareService {
+
+	private final String baseDir = "/home/ubuntu/mallang-static/result/";
+	private final String baseUrl = "https://mallang.info/result/";
+	private final String HTML_EXTENSION = ".html";
+
+	public HtmlSaveResponse saveHtml(String html) {
+		if (!StringUtils.hasText(html)) {
+			throw new CustomException(ResponseCode.INVALID_HTML_FORMAT);
+		}
+
+		try {
+			Path directory = Paths.get(baseDir);
+			if (!Files.exists(directory)) {
+				Files.createDirectories(directory);
+			}
+
+			String filename = UUID.randomUUID() + HTML_EXTENSION;
+			Path filePath = directory.resolve(filename);
+			Files.write(filePath, html.getBytes(StandardCharsets.UTF_8));
+
+			return new HtmlSaveResponse(baseUrl + filename);
+
+		} catch (Exception e) {
+			throw new CustomException(ResponseCode.FILE_SAVE_ERROR);
+		}
+	}
+}


### PR DESCRIPTION
## #️⃣ Issue Number
#35 

## 📝 요약(Summary)
- 프론트엔드에서 전달한 HTML 문자열을 받아 서버에 `.html` 파일로 저장
- 저장된 파일은 `/home/ubuntu/mallang-static/result/` 경로에 위치하며, **Nginx**를 통해 외부에서 접근 가능한 URL(`https://mallang.info/result/{uuid}.html`)로 제공
- 클라이언트는 해당 URL을 통해 저장된 결과 페이지를 공유할 수 있고, 이후 **카카오톡 공유 API 에 활용 예정**

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)
<img width="400" alt="image" src="https://github.com/user-attachments/assets/daae878b-7626-47e8-b49e-01c4653efe48" />

## 💬 공유사항 to 리뷰어
- 현재 기능은 Nginx가 `/result/` 경로를 정적 파일로 서빙하도록 설정되어 있어야 정상 작동합니다.
- 로컬 환경에서는 파일 저장은 되지만 도메인 테스트는 불가능하므로, 실제 배포 서버(`https://mallang.info`)에서 정적 URL이 잘 열리는지 확인이 필요합니다.
- Spring Boot는 `.html`을 내부 리소스가 아닌 외부 경로에 저장하므로, JAR 재배포와 무관하게 파일 접근이 가능합니다.

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
