### PR TITLE
[Feat] - 영화 데이터 주입 및 영화 감정 태그 분류

### DIFF
--- a/src/main/java/backend/spring/config/OpenAiConfig.java
+++ b/src/main/java/backend/spring/config/OpenAiConfig.java
@@ -18,7 +18,7 @@ public class OpenAiConfig {
 	@Value("${openai.api-url}")
 	private String apiUrl;
 
-	@Bean
+	@Bean("openAiWebClient")
 	public WebClient openAiWebClient() { //gpt api 헤더 설정
 		return WebClient.builder()
 			.baseUrl(apiUrl)

--- a/src/main/java/backend/spring/config/TmdbConfig.java
+++ b/src/main/java/backend/spring/config/TmdbConfig.java
@@ -1,0 +1,29 @@
+package backend.spring.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import lombok.Getter;
+
+@Configuration
+@Getter
+public class TmdbConfig {
+    @Value("${tmdb.api-key}")
+    private String apiKey;
+
+    @Value("${tmdb.api-url}")
+    private String apiUrl;
+
+    @Bean("tmdbWebClient")
+    public WebClient tmdbWebClient() { //tmdb api 헤더 설정
+        return WebClient.builder()
+                .baseUrl(apiUrl)
+                .defaultHeader(HttpHeaders.AUTHORIZATION, "Bearer " + apiKey)
+                .defaultHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
+                .build();
+    }
+}

--- a/src/main/java/backend/spring/controller/MovieIngestController.java
+++ b/src/main/java/backend/spring/controller/MovieIngestController.java
@@ -1,0 +1,53 @@
+package backend.spring.controller;
+
+import backend.spring.dto.object.MovieData;
+import backend.spring.dto.object.TmdbData;
+import backend.spring.dto.request.IngestRequestDto;
+import backend.spring.dto.response.IngestResponseDto;
+import backend.spring.service.MovieIngestService;
+import backend.spring.service.client.OpenAiClient;
+import backend.spring.service.client.TmdbClient;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/ingest")
+@RequiredArgsConstructor
+public class MovieIngestController {
+
+    private final MovieIngestService ingest;
+    private final TmdbClient tmdbClient;
+    private final OpenAiClient openAiClient;
+
+    @PostMapping("/{genre}")
+    public Mono<IngestResponseDto> trigger(
+            @PathVariable String genre,
+            @RequestBody IngestRequestDto request) {
+        return ingest.ingestGenre(genre, request.genreId(), request.page());
+    }
+
+    @GetMapping("/test/{movieId}")
+    public ResponseEntity< Mono<TmdbData> > testFetchMovieDetail(@PathVariable String movieId){
+        Mono<TmdbData> response = tmdbClient.fetchMovieDetail(movieId);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/test/{genreId}/{page}")
+    public ResponseEntity< Mono<List<String>> > testFetchMovieID(
+            @PathVariable String genreId,
+            @PathVariable int page){
+        Mono<List<String>> response = tmdbClient.fetchMovieIds(genreId, page);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/test/gpt")
+    public ResponseEntity< Mono<MovieData> > testTranslateGpt(@RequestBody TmdbData request){
+        Mono<MovieData> response = openAiClient.translateAndTag(request);
+        return ResponseEntity.ok(response);
+    }
+
+}

--- a/src/main/java/backend/spring/dto/object/IdListRaw.java
+++ b/src/main/java/backend/spring/dto/object/IdListRaw.java
@@ -1,0 +1,17 @@
+package backend.spring.dto.object;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public record IdListRaw(
+        @JsonProperty("results") List<Item> results) {
+
+    public List<String> toIdList() {
+        return results.stream()
+                .map(item -> String.valueOf(item.id()))
+                .toList();
+    }
+
+    public record Item(@JsonProperty("id") Long id) {}
+}

--- a/src/main/java/backend/spring/dto/object/MovieData.java
+++ b/src/main/java/backend/spring/dto/object/MovieData.java
@@ -1,0 +1,38 @@
+package backend.spring.dto.object;
+
+import backend.spring.entity.Movie;
+
+public record MovieData(
+        String genre,
+
+        String title,
+        String summary,
+        String year,
+        String image,
+        String score,
+
+        String hour,  //movie detail 정보
+        String director,
+        String actor1,
+        String actor2,
+
+        String emotion, //gpt
+        String style
+) {
+    public Movie toMovieEntity(){
+        return Movie.of(
+                genre,
+                title,
+                summary,
+                year,
+                image,
+                score,
+                hour,
+                director,
+                actor1,
+                actor2,
+                emotion,
+                style
+        );
+    }
+}

--- a/src/main/java/backend/spring/dto/object/TmdbData.java
+++ b/src/main/java/backend/spring/dto/object/TmdbData.java
@@ -1,0 +1,34 @@
+package backend.spring.dto.object;
+
+import backend.spring.entity.Movie;
+
+public record TmdbData(
+        String genre,
+
+        String title,
+        String summary,
+        String year,
+        String image,
+        String score,
+
+        String hour,  //movie detail 정보
+        String director,
+        String actor1,
+        String actor2
+) {
+    /** 기존 데이터에 새 genre만 덮어쓴 복사본을 반환 */
+    public TmdbData withGenre(String genre) {
+        return new TmdbData(
+                genre,
+                title,
+                summary,
+                year,
+                image,
+                score,
+                hour,
+                director,
+                actor1,
+                actor2
+        );
+    }
+}

--- a/src/main/java/backend/spring/dto/object/TmdbDetailRaw.java
+++ b/src/main/java/backend/spring/dto/object/TmdbDetailRaw.java
@@ -1,0 +1,51 @@
+package backend.spring.dto.object;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public record TmdbDetailRaw(
+        String title,
+        @JsonProperty("overview") String summary,
+        @JsonProperty("release_date") String releaseDate,
+        @JsonProperty("poster_path") String posterPath,
+        @JsonProperty("vote_average") double vote,
+        Integer runtime,
+        Credits credits) {
+
+    /** Raw → 최종 TMDBResponseDto 로 변환 */
+    public TmdbData toDto() {
+        String image = (posterPath != null)
+                ? "https://image.tmdb.org/t/p/w500" + posterPath
+                : null;
+
+        // 감독
+        String director = credits.crew().stream()
+                .filter(c -> "Director".equals(c.job()))
+                .map(Crew::name)
+                .findFirst()
+                .orElse(null);
+
+        // 배우 1, 2
+        String actor1 = !credits.cast().isEmpty() ? credits.cast().get(0).name() : null;
+        String actor2 = credits.cast().size() > 1 ? credits.cast().get(1).name() : null;
+
+        return new TmdbData(
+                null,
+                title,
+                summary,
+                releaseDate,
+                image,
+                String.format("%.1f", vote),
+                runtime != null ? runtime.toString() : null,
+                director,
+                actor1,
+                actor2
+        );
+    }
+
+    //하위 구조
+    public record Credits(List<Crew> crew, List<Cast> cast) {}
+    public record Crew(String job, String name) {}
+    public record Cast(String name) {}
+}

--- a/src/main/java/backend/spring/dto/request/IngestRequestDto.java
+++ b/src/main/java/backend/spring/dto/request/IngestRequestDto.java
@@ -1,0 +1,7 @@
+package backend.spring.dto.request;
+
+public record IngestRequestDto(
+        String genreId,
+        int page
+) {
+}

--- a/src/main/java/backend/spring/dto/response/IngestResponseDto.java
+++ b/src/main/java/backend/spring/dto/response/IngestResponseDto.java
@@ -1,0 +1,7 @@
+package backend.spring.dto.response;
+
+public record IngestResponseDto(
+        int success,
+        int fail
+) {
+}

--- a/src/main/java/backend/spring/entity/Movie.java
+++ b/src/main/java/backend/spring/entity/Movie.java
@@ -64,4 +64,37 @@ public class Movie {
 	@Enumerated(EnumType.STRING)
 	@Column(nullable = false)
 	private Style style;
+
+	public Movie(String title, String hour, String year, String image, String summary, Double score, String director, String actor1, String actor2, Genre genre, Emotion emotion, Style style) {
+		this.title = title;
+		this.hour = hour;
+		this.year = year;
+		this.image = image;
+		this.summary = summary;
+		this.score = score;
+		this.director = director;
+		this.actor1 = actor1;
+		this.actor2 = actor2;
+		this.genre = genre;
+		this.emotion = emotion;
+		this.style = style;
+	}
+
+	public static Movie of(String genre, String title, String summary, String year, String image, String str_score, String hour, String director, String actor1, String actor2, String emotion, String style){
+		Double score = Double.parseDouble(str_score);
+		return new Movie(
+				title,
+				hour,
+				year,
+				image,
+				summary,
+				score,
+				director,
+				actor1,
+				actor2,
+				Genre.from(genre),
+				Emotion.from(emotion),
+				Style.from(style)
+		);
+	}
 }

--- a/src/main/java/backend/spring/exception/ResponseCode.java
+++ b/src/main/java/backend/spring/exception/ResponseCode.java
@@ -9,7 +9,10 @@ public enum ResponseCode {
 	NO_RECOMMENDATION_FOUND(404, "조건에 맞는 영화가 없습니다."),
 	INVALID_FORMAT(400, "잘못된 입력 형식 입니다."),
 	OPENAI_LIMIT(400, "gpt api의 사용량을 초과했습니다."),
-	INVALID_ENUM_FORMAT(400, "잘못된 입력 형식입니다.");
+	INVALID_ENUM_FORMAT(400, "잘못된 입력 형식입니다."),
+	TMDB_RATE_LIMIT(429, "TMDB 요청 한도 초과"),
+	TMDB_NOT_FOUND(404,"해당 movie id를 찾을 수 없습니다."),
+	TMDB_API_ERROR(503, "tmdb 서버 오류입니다.");
 
 	private final int status;
 	private final String message;

--- a/src/main/java/backend/spring/repository/TodayWordRepository.java
+++ b/src/main/java/backend/spring/repository/TodayWordRepository.java
@@ -2,10 +2,21 @@ package backend.spring.repository;
 
 import java.util.Optional;
 
+import backend.spring.entity.type.Emotion;
+import backend.spring.entity.type.Style;
+import backend.spring.entity.type.Tone;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import backend.spring.entity.TodayWord;
 
 public interface TodayWordRepository extends JpaRepository<TodayWord, Long> {
-	Optional<TodayWord> findByEmotionAndStyleAndTone(String emotion, String style, String tone);
+	Optional<TodayWord> findByEmotionAndStyleAndTone(Emotion emotion, Style style, Tone tone);
+
+	default Optional<TodayWord> findByKeys(String emotionKey, String styleKey, String toneKey) {
+		return findByEmotionAndStyleAndTone(
+				Emotion.from(emotionKey),
+				Style.from(styleKey),
+				Tone.from(toneKey)
+		);
+	}
 }

--- a/src/main/java/backend/spring/service/MovieIngestService.java
+++ b/src/main/java/backend/spring/service/MovieIngestService.java
@@ -1,0 +1,58 @@
+package backend.spring.service;
+
+import backend.spring.dto.object.TmdbData;
+import backend.spring.dto.response.IngestResponseDto;
+import backend.spring.repository.MovieRepository;
+import backend.spring.service.client.OpenAiClient;
+import backend.spring.service.client.TmdbClient;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class MovieIngestService {
+
+    private final TmdbClient tmdb;
+    private final OpenAiClient gpt;
+    private final MovieRepository movieRepo;
+
+    /** 장르·페이지 단위 전체 ingest */
+    public Mono<IngestResponseDto> ingestGenre(String genre, String genreId, int page) {
+
+        AtomicInteger ok = new AtomicInteger();
+        AtomicInteger fail = new AtomicInteger();
+
+        return tmdb.fetchMovieIds(genreId, page)        // id 목록 가져옴
+                .flatMapMany(Flux::fromIterable)
+                // id별 detail, gpt 호출 (10개 병렬)
+                .parallel(10)
+                .runOn(Schedulers.boundedElastic())
+                .flatMap(id -> tmdb.fetchMovieDetail(id) //입력받은 장르를 새로 저장
+                        .map(d -> d.withGenre(genre)))
+                .flatMap(this::translateSave)
+                .sequential()
+                .doOnNext(v -> ok.incrementAndGet())
+                .onErrorContinue((e, obj) -> {
+                    fail.incrementAndGet();
+                    log.error("❌ save 실패 id={} / 예외={}", obj, e.getMessage(), e);
+                })
+                .then(Mono.fromSupplier(() -> new IngestResponseDto(ok.get(), fail.get())));
+    }
+
+    /** detail → GPT → DB 저장 */
+    private Mono<Void> translateSave(TmdbData detail) {
+        return gpt.translateAndTag(detail)
+                .flatMap(movieData ->
+                        Mono.fromCallable(() -> movieRepo.save(movieData.toMovieEntity()))
+                                .subscribeOn(Schedulers.boundedElastic())     // 블로킹 전용 스레드
+                )
+                .then();
+    }
+}

--- a/src/main/java/backend/spring/service/OpenAiService.java
+++ b/src/main/java/backend/spring/service/OpenAiService.java
@@ -1,35 +1,24 @@
 package backend.spring.service;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-
 import backend.spring.dto.request.ChatRequestDto;
 import backend.spring.dto.response.ChatResponseDto;
-import backend.spring.exception.CustomException;
-import backend.spring.exception.ResponseCode;
+import backend.spring.service.client.OpenAiClient;
 import jakarta.transaction.Transactional;
-import org.springframework.beans.factory.annotation.Qualifier;
+
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.web.reactive.function.client.WebClient;
-import org.springframework.web.reactive.function.client.WebClientResponseException;
 
 import backend.spring.entity.TodayWord;
 import backend.spring.repository.TodayWordRepository;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 
 @Service
+@RequiredArgsConstructor
 public class OpenAiService {
 
-	private final WebClient webClient;
+	private final OpenAiClient gpt;
 	private final TodayWordRepository todayWordRepository;
-
-	//service 클래스 생성자
-	public OpenAiService(@Qualifier("openAiWebClient") WebClient webClient, TodayWordRepository todayWordRepository) {
-		this.webClient = webClient;
-		this.todayWordRepository = todayWordRepository;
-	}
 
 	@Transactional
 	public Mono<ChatResponseDto> getChatCompletionAsync(ChatRequestDto request) {
@@ -38,66 +27,18 @@ public class OpenAiService {
 		String style = request.style();
 		String tone = request.tone();
 
-		//db에 해당 조합이 존재하는지 확인
-		Optional<TodayWord> todayWord = todayWordRepository.findByEmotionAndStyleAndTone(emotion, style, tone);
-		if (todayWord.isPresent()) {
-			String word = todayWord.get().getWord();
-			return Mono.just(new ChatResponseDto(word));
-		}
-
-		// 0. 사용자 태그 가져와 스크립트에 추가
-		String script =
-				"너는 심리 상담 전문가이며, 감정적으로 지친 사람들에게 공감 어린 말과 위로를 해주는 역할을 하고 있어. "
-				+ "말투는 따뜻하고 조용하며, 강요하지 않도록 유의해. 문장은 하나의 단락으로 이어서 써야 하며, 절대 줄바꿈을 하지 마. '\\n' 문자도 쓰지 마. "
-				+ "결과는 하나의 자연스러운 문장 흐름으로, 문단이 끊기지 않도록 써줘. 항목을 구분하지 말고 연결해서 문단 하나로 써줘. "
-				+ "예시: '지루한 하루 속에서도 당신이 새로운 기분 전환을 시도하려는 모습이 참 멋져요. 이런 태도는 일상에 작은 활력을 불어넣을 수 있어요. 오늘 하루도 당신은 충분히 잘해내고 있어요.' 이런 식으로, 구조가 드러나지 않도록 써줘."
-				+ "\n"
-				+ "사용자 정보:\n"
-				+ "- 감정 상태: " + emotion + "\n"
-				+ "- 감정 해소 방식: " + style + "\n"
-				+ "- 듣고 싶은 말의 톤: " + tone + "\n"
-				+ "\n"
-				+ "이 정보를 바탕으로 한 문단의 감성적인 문장을 작성해주세요. 문장은 하나로 이어지며, 영화에 대한 언급도 자연스럽게 포함시켜 주세요. 500자 이내로 써주세요.";
-
-		// 1. 메시지 리스트 구성
-		List<Map<String, String>> messages = new ArrayList<>();
-		// system 메시지
-		Map<String, String> systemMsg = Map.of(
-			"role", "system",
-			"content", script
-		);
-		// user 메시지 (요청 트리거 역할)
-		Map<String, String> userMsg = Map.of(
-			"role", "user",
-			"content", "결과지를 작성해줘"
-		);
-		messages.add(systemMsg);
-		messages.add(userMsg);
-
-		// 2. 최종 요청 payload 구성
-		Map<String, Object> requestPayload = Map.of(
-			"model", "gpt-3.5-turbo",
-			"temperature", 0.7,
-			"messages", messages
-		);
-
-		return webClient.post()  //gpt api에 post 요청
-			.bodyValue(requestPayload) //model+message 같이 보냄
-			.retrieve()  // 응답 받기 준비
-			.bodyToMono(Map.class) //응답(json)을 Mono<Map>으로 변환
-			.flatMap(response -> { //gpt에게 응답(response) 받아 저장
-				Map choice = (Map)((List)response.get("choices")).get(0);
-				Map message = (Map)choice.get("message");
-				String content = (String)message.get("content");
-
-				todayWordRepository.save(TodayWord.of(emotion, style, tone, content));
-				return Mono.just(new ChatResponseDto(content));
-			})
-			.onErrorResume(WebClientResponseException.TooManyRequests.class, e -> {
-				return Mono.error(new CustomException(ResponseCode.OPENAI_LIMIT)); //gpt 제한 초과
-			})
-			.onErrorResume(WebClientResponseException.class, e -> {
-				return Mono.error(new CustomException(ResponseCode.INVALID_FORMAT)); // 나머지 모든 4xx, 5xx 오류: 일반적인 GPT 오류 처리
-			});
+		return Mono.fromCallable(() -> todayWordRepository.findByKeys(emotion, style, tone)) //db 조회
+				.subscribeOn(Schedulers.boundedElastic())        // JPA 블로킹 → 전용 스레드
+				.flatMap(opt -> opt                             // 존재하면 즉시 반환
+						.<Mono<ChatResponseDto>>map(tw -> Mono.just(new ChatResponseDto(tw.getWord())))
+						.orElseGet(() -> gpt.gptMessage(emotion, style, tone)   /* ② GPT 호출 + DB 저장 */
+										.flatMap(message ->
+												Mono.fromCallable( () -> todayWordRepository.save(TodayWord.of(emotion, style, tone, message)) )
+														.subscribeOn(Schedulers.boundedElastic())   // 저장도 블로킹
+														.thenReturn(message)                        // message 그대로 방출
+										)
+										.map(ChatResponseDto::new)                      // String → DTO
+						)
+				);
 	}
 }

--- a/src/main/java/backend/spring/service/client/OpenAiClient.java
+++ b/src/main/java/backend/spring/service/client/OpenAiClient.java
@@ -1,0 +1,215 @@
+package backend.spring.service.client;
+
+import backend.spring.dto.object.MovieData;
+import backend.spring.dto.object.TmdbData;
+import backend.spring.exception.CustomException;
+import backend.spring.exception.ResponseCode;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import reactor.core.publisher.Mono;
+import reactor.util.retry.Retry;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.springframework.http.HttpStatus.*;
+
+@Component
+public class OpenAiClient {
+
+    private final WebClient gptWebClient;
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    public OpenAiClient(@Qualifier("openAiWebClient") WebClient gptwebClient) {
+        this.gptWebClient = gptwebClient;
+    }
+
+    /* ────────────────── 공통 예외 ────────────────── */
+    private RuntimeException mapOpenAiException(WebClientResponseException ex) {
+        return switch (ex.getStatusCode()) {
+            case TOO_MANY_REQUESTS -> new CustomException(ResponseCode.OPENAI_LIMIT);
+            case BAD_REQUEST       -> new CustomException(ResponseCode.INVALID_FORMAT);
+            default                -> new CustomException(ResponseCode.INVALID_FORMAT);
+        };
+    }
+
+    /* ────────────────── 영화 번역 + 감정 태그 ────────────────── */
+    public Mono<MovieData> translateAndTag(TmdbData src) {
+        Map<String, Object> payload = movieBuildPrompt(src);
+
+        return gptWebClient.post()
+                .bodyValue(payload)
+                .exchangeToMono(this::handleMovieResponse)
+                .retryWhen(Retry.backoff(3, Duration.ofSeconds(2)));
+    }
+    /** 영화 번역·감정 태그용: OpenAI JSON → MovieData */
+    private Mono<MovieData> handleMovieResponse(ClientResponse res) {
+        if (res.statusCode().is2xxSuccessful()) {
+            return res.bodyToMono(Map.class)          // OpenAI 원본 JSON
+                    .map(this::parseResult);   // ➜ MovieData
+        }
+        return res.createException()
+                .flatMap(ex -> Mono.error(mapOpenAiException(ex)));
+    }
+    @SuppressWarnings("unchecked")
+    private MovieData parseResult(Map<?, ?> rawJson) {
+        try {
+            // 1. choices → [ { message: { content: "{...}" } } ]
+            List<Map<String, Object>> choices = (List<Map<String, Object>>) rawJson.get("choices");
+            Map<String, Object> message = (Map<String, Object>) choices.get(0).get("message");
+
+            // 2. content는 문자열 형태의 JSON → 다시 파싱
+            String jsonString = (String) message.get("content");
+            Map<String, Object> content = MAPPER.readValue(jsonString, new TypeReference<>() {});
+
+            // 3. MovieData 생성 (GPT에서 받은 필드만 사용)
+            return new MovieData(
+                    (String) content.get("genre"),
+                    (String) content.get("title"),
+                    (String) content.get("summary"),
+                    (String) content.get("year"),
+                    (String) content.get("image"),
+                    (String) content.get("score"),
+                    (String) content.get("hour"),
+                    (String) content.get("director"),
+                    (String) content.get("actor1"),
+                    (String) content.get("actor2"),
+                    (String) content.get("emotion"),
+                    (String) content.get("style")
+            );
+        } catch (Exception e) {
+            throw new IllegalStateException("GPT 응답 파싱 실패", e);
+        }
+    }
+    // 스크립트 build
+    public Map<String, Object> movieBuildPrompt(TmdbData src) {
+        try{
+            // 0. 시스템 프롬프트
+            String script = """
+                당신은 영화 분석 전문가입니다. 다음 JSON 객체를 분석하고 아래 지시를 따르세요:
+                
+                1. "title", "summary", "director", "actor1", "actor2" 값을 영어에서 한국어로 번역하세요.
+                2. 관객이 이 영화를 보며 가장 느낄 감정(emotion)을 정확히 하나 선택하세요.  
+                   선택지: 슬픔, 행복, 지루함, 스트레스
+                3. 해당 감정을 해소하거나 조화시키는 방식(style)을 정확히 하나 선택하세요.  
+                   선택지: 몰입감, 웃긴, 기분전환, 위로
+                4. 번역된 값과 선택한 감정 정보(emotion, style)를 포함한 **단일 JSON 객체**를 반환하세요.
+                   반드시 원시 JSON만 출력하세요. 줄바꿈 없이.
+                
+                예시 출력:
+                {
+                  "genre": "드라마",
+                  "title": "스파이더맨: 홈커밍",
+                  "summary": "캡틴 아메리카: 시빌 워 사건 이후, 퀸스의 평범한 고등학생 피터 파커는 멘토인 토니 스타크의 도움을 받으며 영웅 ‘스파이더맨’과 학생 생활을 병행하려고 애쓴다. 그러던 중 새로운 악당 벌처가 등장하자 피터는 도시에 닥친 위협에 맞서야 한다.",
+                  "year": "2017-07-05",
+                  "image": "https://image.tmdb.org/t/p/w500/c24sv2weTHPsmDa7jEMN0m2P3RT.jpg",
+                  "score": "7.3",
+                  "hour": "133",
+                  "director": "존 왓츠",
+                  "actor1": "톰 홀랜드",
+                  "actor2": "마이클 키튼",
+                  "emotion": "행복",
+                  "style": "몰입감"
+                }
+                """;
+
+            // 1. 메시지 구성
+            Map<String, String> systemMsg = Map.of("role", "system", "content", script);
+
+            Map<String, Object> movieMap = new LinkedHashMap<>();
+            movieMap.put("genre",    src.genre());
+            movieMap.put("title",    src.title());
+            movieMap.put("summary",  src.summary());
+            movieMap.put("year",     src.year());
+            movieMap.put("image",    src.image());
+            movieMap.put("score",    src.score());
+            movieMap.put("hour",     src.hour());
+            movieMap.put("director", src.director());
+            movieMap.put("actor1",   src.actor1());
+            movieMap.put("actor2",   src.actor2());
+
+            String userJson = MAPPER.writeValueAsString(movieMap);
+
+            return Map.of(
+                    "model",           "gpt-3.5-turbo-0125",
+                    "temperature",     0.0,
+                    "response_format", Map.of("type", "json_object"),
+                    "messages",        List.of(systemMsg, Map.of("role","user","content",userJson))
+            );
+        } catch (JsonProcessingException e) {
+            // 직렬화 실패 → 논리적으로 잘못된 입력이므로 런타임 예외로 래핑
+            throw new IllegalStateException("영화 정보를 JSON 문자열로 변환할 수 없습니다.", e);
+        }
+    }
+
+
+    /* ────────────────── Today-Word 메시지 ────────────────── */
+    public Mono<String> gptMessage(String emotion, String style, String tone) {
+        Map<String, Object> payload = wordBuildPrompt(emotion, style, tone);
+
+        return gptWebClient.post()
+                .bodyValue(payload)
+                .exchangeToMono(this::handleWordResponse);
+    }
+    /** Today-Word 용: OpenAI JSON → String */
+    private Mono<String> handleWordResponse(ClientResponse res) {
+        if (res.statusCode().is2xxSuccessful()) {
+            return res.bodyToMono(Map.class)
+                    .map(json -> {
+                        Map<?, ?> choice  = (Map<?, ?>) ((List<?>) json.get("choices")).getFirst();
+                        Map<?, ?> message = (Map<?, ?>) choice.get("message");
+                        return (String) message.get("content");   // ← 바로 추출
+                    });
+        }
+        return res.createException()
+                .flatMap(ex -> Mono.error(mapOpenAiException(ex)));
+    }
+    public Map<String, Object> wordBuildPrompt(String emotion, String style, String tone){
+        // 0. 사용자 태그 가져와 스크립트에 추가
+        String script =
+                "너는 심리 상담 전문가이며, 감정적으로 지친 사람들에게 공감 어린 말과 위로를 해주는 역할을 하고 있어. "
+                        + "말투는 따뜻하고 조용하며, 강요하지 않도록 유의해. 문장은 하나의 단락으로 이어서 써야 하며, 절대 줄바꿈을 하지 마. '\\n' 문자도 쓰지 마. "
+                        + "결과는 하나의 자연스러운 문장 흐름으로, 문단이 끊기지 않도록 써줘. 항목을 구분하지 말고 연결해서 문단 하나로 써줘. "
+                        + "예시: '지루한 하루 속에서도 당신이 새로운 기분 전환을 시도하려는 모습이 참 멋져요. 이런 태도는 일상에 작은 활력을 불어넣을 수 있어요. 오늘 하루도 당신은 충분히 잘해내고 있어요.' 이런 식으로, 구조가 드러나지 않도록 써줘."
+                        + "\n"
+                        + "사용자 정보:\n"
+                        + "- 감정 상태: " + emotion + "\n"
+                        + "- 감정 해소 방식: " + style + "\n"
+                        + "- 듣고 싶은 말의 톤: " + tone + "\n"
+                        + "\n"
+                        + "이 정보를 바탕으로 한 문단의 감성적인 문장을 작성해주세요. 문장은 하나로 이어지며, 영화에 대한 언급도 자연스럽게 포함시켜 주세요. 500자 이내로 써주세요.";
+
+        // 1. 메시지 구성
+        List<Map<String, String>> messages = new ArrayList<>();
+        // system 메시지
+        Map<String, String> systemMsg = Map.of(
+                "role", "system",
+                "content", script
+        );
+        // user 메시지 (요청 트리거 역할)
+        Map<String, String> userMsg = Map.of(
+                "role", "user",
+                "content", "결과지를 작성해줘"
+        );
+        messages.add(systemMsg);
+        messages.add(userMsg);
+
+        // 2. 최종 요청 payload 구성
+        Map<String, Object> requestPlayload = Map.of(
+                "model", "gpt-3.5-turbo",
+                "temperature", 0.7,
+                "messages", messages
+        );
+
+        return requestPlayload;
+    }
+
+}

--- a/src/main/java/backend/spring/service/client/TmdbClient.java
+++ b/src/main/java/backend/spring/service/client/TmdbClient.java
@@ -1,0 +1,84 @@
+package backend.spring.service.client;
+
+import backend.spring.dto.object.IdListRaw;
+import backend.spring.dto.object.TmdbDetailRaw;
+import backend.spring.dto.object.TmdbData;
+import backend.spring.exception.CustomException;
+import backend.spring.exception.ResponseCode;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import reactor.core.publisher.Mono;
+import reactor.util.retry.Retry;
+
+import java.time.Duration;
+import java.util.List;
+
+import static org.springframework.http.HttpStatus.*;
+
+@Component
+public class TmdbClient {
+
+    private final WebClient tmdbWebClient;
+    public TmdbClient ( @Qualifier("tmdbWebClient") WebClient tmdbWebClient){
+        this.tmdbWebClient = tmdbWebClient;
+    }
+
+    /* 1) discover → id 목록 */
+    public Mono<List<String>> fetchMovieIds(String genreId, int page) {
+        return tmdbWebClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .path("/discover/movie")
+                        .queryParam("language", "en-US")
+                        .queryParam("with_genres", genreId)
+                        .queryParam("include_adult", "false")
+                        .queryParam("sort_by", "popularity.desc")
+                        .queryParam("page", page)
+                        .build())
+                .exchangeToMono(this::handleIdsResponse)
+                .retryWhen(Retry.backoff(3, Duration.ofSeconds(2)));
+    }
+
+    /* 2) detail + credits */
+    public Mono<TmdbData> fetchMovieDetail(String movieId) {
+        return tmdbWebClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .path("/movie/{id}")
+                        .queryParam("language", "en-US")
+                        .queryParam("append_to_response", "credits")
+                        .build(movieId))
+                .exchangeToMono(this::handleDetailResponse)
+                .retryWhen(Retry.backoff(3, Duration.ofSeconds(2)));
+    }
+
+    /* ===== 공통 처리 ===== */
+
+    private Mono<List<String>> handleIdsResponse(ClientResponse res) {
+        if (res.statusCode().is2xxSuccessful()) {
+            return res.bodyToMono(IdListRaw.class).map(IdListRaw::toIdList);
+        }
+        return res.createException()         // WebClientResponseException 으로 변환
+                .flatMap(ex -> Mono.error(mapException(ex)));
+    }
+
+    private Mono<TmdbData> handleDetailResponse(ClientResponse res) {
+        if (res.statusCode().is2xxSuccessful()) {
+            return res.bodyToMono(TmdbDetailRaw.class)
+                    .map(TmdbDetailRaw::toDto);
+        }
+        return res.createException()
+                .flatMap(ex -> Mono.error(mapException(ex)));
+    }
+
+    /** ★ 핵심: HTTP → ResponseCode → CustomException */
+    private RuntimeException mapException(WebClientResponseException ex) {
+        return switch (ex.getStatusCode()) {
+            case TOO_MANY_REQUESTS -> new CustomException(ResponseCode.TMDB_RATE_LIMIT);
+            case NOT_FOUND         -> new CustomException(ResponseCode.TMDB_NOT_FOUND);
+            case BAD_REQUEST       -> new CustomException(ResponseCode.INVALID_FORMAT);
+            default                -> new CustomException(ResponseCode.TMDB_API_ERROR);
+        };
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,8 +22,8 @@ logging:
     org.springframework.web.socket: debug
 
 openai:
-  api-key: ${API_KEY}
-  api-url: https://api.openai.com/v1/chat/completions
+  api-key: ${AI_API_KEY}
+  api-url: ${AI_API_URL}
 
 tmdb:
   api-key: ${TM_API_KEY}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,3 +24,7 @@ logging:
 openai:
   api-key: ${API_KEY}
   api-url: https://api.openai.com/v1/chat/completions
+
+tmdb:
+  api-key: ${TM_API_KEY}
+  api-url: ${TM_API_URL}


### PR DESCRIPTION
## #️⃣ Issue Number

#34 

## 📝 요약(Summary)
📌 TMDB → GPT → DB 영화 주입 파이프라인 구현
- TMDB 영화 데이터를 가져와 GPT로 번역 및 감정 태그를 생성하고, DB에 저장하는 비동기 파이프라인 구현

📈 기대 효과
- 장르 기반 영화 데이터 수집 자동화
- GPT를 통한 감정 기반 추천 시스템에 필요한 데이터 구축
- 병렬 처리 및 WebClient 기반으로 대량 호출에도 확장 가능

🔧 구현 구성
1. TmdbClient
- TMDB WebClient 호출 전용 컴포넌트
/discover/movie: 장르/페이지에 따른 영화 ID 목록 조회 (fetchMovieIds) : page 당 한번에 20개씩 조회 가능
/movie/{id}?append_to_response=credits: 영화 상세 + 감독/배우 정보 수집 (fetchMovieDetail)

2. OpenAiClient
- GPT API 호출 및 파싱 처리
영화 데이터를 기반으로 번역 + 감정(emotion) + 스타일(style) 정보 생성 (translateAndTag)
응답 문자열에서 MovieData로 파싱 (parseResult)
_마음처방전에 쓰이는 gpt api도 여기서 처리_

3. MovieIngestService
- TMDB → GPT → DB 저장까지의 전체 흐름 처리
ingestGenre(): 장르와 페이지를 기반으로 20개의 영화 데이터 저장 로직 처리
_영화 ID 목록 조회 → 반복: [ id별 데이터 상세 조회 → GPT 처리 ] → 저장_
병렬 처리(parallel(10)), 예외 개별 처리(onErrorContinue)로 대량 처리 최적화
성공/실패 개수는 IngestResponseDto로 반환

4. MovieIngestController
- 수동 테스트 및 API 트리거용 엔드포인트 제공
/api/ingest/{genre}: 개발자가 원할 때마다 api 호출 가능


## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

/api/ingest/{genre} 실행시, 
저장할 장르를 고르고, 그에 맞는 장르 번호를 선택, 페이지를 바꿔가며 api 호출

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
